### PR TITLE
Rename proto messages and redefine types

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -17,15 +17,12 @@ class RecognizeVoice {
   }
 
   Future<void> startRecognition() async {
-    await stub.recognize(Control()
-      ..start = true
-      ..stop = false);
+    await stub.recognize(RecognizerControl()..action = RecognizerAction.START);
   }
 
   Future<void> stopRecognition() async {
-    final response = await stub.recognize(Control()
-      ..start = false
-      ..stop = true);
+    final response = await stub
+        .recognize(RecognizerControl()..action = RecognizerAction.STOP);
     output = response.result;
   }
 }

--- a/app/lib/src/generated/recognize.pb.dart
+++ b/app/lib/src/generated/recognize.pb.dart
@@ -9,75 +9,65 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-class Control extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Control', createEmptyInstance: create)
-    ..aOB(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'start')
-    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'stop')
+import 'recognize.pbenum.dart';
+
+export 'recognize.pbenum.dart';
+
+class RecognizerControl extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RecognizerControl', createEmptyInstance: create)
+    ..e<RecognizerAction>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'action', $pb.PbFieldType.OE, defaultOrMaker: RecognizerAction.START, valueOf: RecognizerAction.valueOf, enumValues: RecognizerAction.values)
     ..hasRequiredFields = false
   ;
 
-  Control._() : super();
-  factory Control({
-    $core.bool? start,
-    $core.bool? stop,
+  RecognizerControl._() : super();
+  factory RecognizerControl({
+    RecognizerAction? action,
   }) {
     final _result = create();
-    if (start != null) {
-      _result.start = start;
-    }
-    if (stop != null) {
-      _result.stop = stop;
+    if (action != null) {
+      _result.action = action;
     }
     return _result;
   }
-  factory Control.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Control.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory RecognizerControl.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RecognizerControl.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
   'Will be removed in next major version')
-  Control clone() => Control()..mergeFromMessage(this);
+  RecognizerControl clone() => RecognizerControl()..mergeFromMessage(this);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Control copyWith(void Function(Control) updates) => super.copyWith((message) => updates(message as Control)) as Control; // ignore: deprecated_member_use
+  RecognizerControl copyWith(void Function(RecognizerControl) updates) => super.copyWith((message) => updates(message as RecognizerControl)) as RecognizerControl; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static Control create() => Control._();
-  Control createEmptyInstance() => create();
-  static $pb.PbList<Control> createRepeated() => $pb.PbList<Control>();
+  static RecognizerControl create() => RecognizerControl._();
+  RecognizerControl createEmptyInstance() => create();
+  static $pb.PbList<RecognizerControl> createRepeated() => $pb.PbList<RecognizerControl>();
   @$core.pragma('dart2js:noInline')
-  static Control getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Control>(create);
-  static Control? _defaultInstance;
+  static RecognizerControl getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RecognizerControl>(create);
+  static RecognizerControl? _defaultInstance;
 
   @$pb.TagNumber(1)
-  $core.bool get start => $_getBF(0);
+  RecognizerAction get action => $_getN(0);
   @$pb.TagNumber(1)
-  set start($core.bool v) { $_setBool(0, v); }
+  set action(RecognizerAction v) { setField(1, v); }
   @$pb.TagNumber(1)
-  $core.bool hasStart() => $_has(0);
+  $core.bool hasAction() => $_has(0);
   @$pb.TagNumber(1)
-  void clearStart() => clearField(1);
-
-  @$pb.TagNumber(2)
-  $core.bool get stop => $_getBF(1);
-  @$pb.TagNumber(2)
-  set stop($core.bool v) { $_setBool(1, v); }
-  @$pb.TagNumber(2)
-  $core.bool hasStop() => $_has(1);
-  @$pb.TagNumber(2)
-  void clearStop() => clearField(2);
+  void clearAction() => clearField(1);
 }
 
-class Result extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Result', createEmptyInstance: create)
+class RecognizerResult extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'RecognizerResult', createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'result')
     ..hasRequiredFields = false
   ;
 
-  Result._() : super();
-  factory Result({
+  RecognizerResult._() : super();
+  factory RecognizerResult({
     $core.String? result,
   }) {
     final _result = create();
@@ -86,26 +76,26 @@ class Result extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Result.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Result.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory RecognizerResult.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RecognizerResult.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
   'Will be removed in next major version')
-  Result clone() => Result()..mergeFromMessage(this);
+  RecognizerResult clone() => RecognizerResult()..mergeFromMessage(this);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Result copyWith(void Function(Result) updates) => super.copyWith((message) => updates(message as Result)) as Result; // ignore: deprecated_member_use
+  RecognizerResult copyWith(void Function(RecognizerResult) updates) => super.copyWith((message) => updates(message as RecognizerResult)) as RecognizerResult; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static Result create() => Result._();
-  Result createEmptyInstance() => create();
-  static $pb.PbList<Result> createRepeated() => $pb.PbList<Result>();
+  static RecognizerResult create() => RecognizerResult._();
+  RecognizerResult createEmptyInstance() => create();
+  static $pb.PbList<RecognizerResult> createRepeated() => $pb.PbList<RecognizerResult>();
   @$core.pragma('dart2js:noInline')
-  static Result getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Result>(create);
-  static Result? _defaultInstance;
+  static RecognizerResult getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RecognizerResult>(create);
+  static RecognizerResult? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get result => $_getSZ(0);

--- a/app/lib/src/generated/recognize.pbenum.dart
+++ b/app/lib/src/generated/recognize.pbenum.dart
@@ -5,3 +5,22 @@
 // @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
+// ignore_for_file: UNDEFINED_SHOWN_NAME
+import 'dart:core' as $core;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class RecognizerAction extends $pb.ProtobufEnum {
+  static const RecognizerAction START = RecognizerAction._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'START');
+  static const RecognizerAction STOP = RecognizerAction._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STOP');
+
+  static const $core.List<RecognizerAction> values = <RecognizerAction> [
+    START,
+    STOP,
+  ];
+
+  static final $core.Map<$core.int, RecognizerAction> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static RecognizerAction? valueOf($core.int value) => _byValue[value];
+
+  const RecognizerAction._($core.int v, $core.String n) : super(v, n);
+}
+

--- a/app/lib/src/generated/recognize.pbgrpc.dart
+++ b/app/lib/src/generated/recognize.pbgrpc.dart
@@ -14,17 +14,20 @@ import 'recognize.pb.dart' as $0;
 export 'recognize.pb.dart';
 
 class RecognizerServiceClient extends $grpc.Client {
-  static final _$recognize = $grpc.ClientMethod<$0.Control, $0.Result>(
-      '/RecognizerService/Recognize',
-      ($0.Control value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.Result.fromBuffer(value));
+  static final _$recognize =
+      $grpc.ClientMethod<$0.RecognizerControl, $0.RecognizerResult>(
+          '/RecognizerService/Recognize',
+          ($0.RecognizerControl value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) =>
+              $0.RecognizerResult.fromBuffer(value));
 
   RecognizerServiceClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
       $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.Result> recognize($0.Control request,
+  $grpc.ResponseFuture<$0.RecognizerResult> recognize(
+      $0.RecognizerControl request,
       {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$recognize, request, options: options);
   }
@@ -34,20 +37,20 @@ abstract class RecognizerServiceBase extends $grpc.Service {
   $core.String get $name => 'RecognizerService';
 
   RecognizerServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.Control, $0.Result>(
+    $addMethod($grpc.ServiceMethod<$0.RecognizerControl, $0.RecognizerResult>(
         'Recognize',
         recognize_Pre,
         false,
         false,
-        ($core.List<$core.int> value) => $0.Control.fromBuffer(value),
-        ($0.Result value) => value.writeToBuffer()));
+        ($core.List<$core.int> value) => $0.RecognizerControl.fromBuffer(value),
+        ($0.RecognizerResult value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.Result> recognize_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.Control> request) async {
+  $async.Future<$0.RecognizerResult> recognize_Pre($grpc.ServiceCall call,
+      $async.Future<$0.RecognizerControl> request) async {
     return recognize(call, await request);
   }
 
-  $async.Future<$0.Result> recognize(
-      $grpc.ServiceCall call, $0.Control request);
+  $async.Future<$0.RecognizerResult> recognize(
+      $grpc.ServiceCall call, $0.RecognizerControl request);
 }

--- a/app/lib/src/generated/recognize.pbjson.dart
+++ b/app/lib/src/generated/recognize.pbjson.dart
@@ -8,24 +8,34 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
-@$core.Deprecated('Use controlDescriptor instead')
-const Control$json = const {
-  '1': 'Control',
+@$core.Deprecated('Use recognizerActionDescriptor instead')
+const RecognizerAction$json = const {
+  '1': 'RecognizerAction',
   '2': const [
-    const {'1': 'start', '3': 1, '4': 1, '5': 8, '10': 'start'},
-    const {'1': 'stop', '3': 2, '4': 1, '5': 8, '10': 'stop'},
+    const {'1': 'START', '2': 0},
+    const {'1': 'STOP', '2': 1},
   ],
 };
 
-/// Descriptor for `Control`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List controlDescriptor = $convert.base64Decode('CgdDb250cm9sEhQKBXN0YXJ0GAEgASgIUgVzdGFydBISCgRzdG9wGAIgASgIUgRzdG9w');
-@$core.Deprecated('Use resultDescriptor instead')
-const Result$json = const {
-  '1': 'Result',
+/// Descriptor for `RecognizerAction`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List recognizerActionDescriptor = $convert.base64Decode('ChBSZWNvZ25pemVyQWN0aW9uEgkKBVNUQVJUEAASCAoEU1RPUBAB');
+@$core.Deprecated('Use recognizerControlDescriptor instead')
+const RecognizerControl$json = const {
+  '1': 'RecognizerControl',
+  '2': const [
+    const {'1': 'action', '3': 1, '4': 1, '5': 14, '6': '.RecognizerAction', '10': 'action'},
+  ],
+};
+
+/// Descriptor for `RecognizerControl`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List recognizerControlDescriptor = $convert.base64Decode('ChFSZWNvZ25pemVyQ29udHJvbBIpCgZhY3Rpb24YASABKA4yES5SZWNvZ25pemVyQWN0aW9uUgZhY3Rpb24=');
+@$core.Deprecated('Use recognizerResultDescriptor instead')
+const RecognizerResult$json = const {
+  '1': 'RecognizerResult',
   '2': const [
     const {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
   ],
 };
 
-/// Descriptor for `Result`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resultDescriptor = $convert.base64Decode('CgZSZXN1bHQSFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQ=');
+/// Descriptor for `RecognizerResult`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List recognizerResultDescriptor = $convert.base64Decode('ChBSZWNvZ25pemVyUmVzdWx0EhYKBnJlc3VsdBgBIAEoCVIGcmVzdWx0');

--- a/python-server/recognize.proto
+++ b/python-server/recognize.proto
@@ -1,14 +1,19 @@
 syntax = "proto3";
 
 service RecognizerService {
-  rpc Recognize (Control) returns (Result);
+  rpc Recognize (RecognizerControl) returns (RecognizerResult);
 }
 
-message Control {
-  bool start = 1;
-  bool stop = 2;
+enum RecognizerAction {
+  START = 0;
+  STOP = 1;
 }
 
-message Result {
+message RecognizerControl {
+  RecognizerAction action = 1;
+}
+
+
+message RecognizerResult {
   string result = 1;
 }

--- a/python-server/recognize_pb2.py
+++ b/python-server/recognize_pb2.py
@@ -13,17 +13,19 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0frecognize.proto\"&\n\x07\x43ontrol\x12\r\n\x05start\x18\x01 \x01(\x08\x12\x0c\n\x04stop\x18\x02 \x01(\x08\"\x18\n\x06Result\x12\x0e\n\x06result\x18\x01 \x01(\t23\n\x11RecognizerService\x12\x1e\n\tRecognize\x12\x08.Control\x1a\x07.Resultb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0frecognize.proto\"6\n\x11RecognizerControl\x12!\n\x06\x61\x63tion\x18\x01 \x01(\x0e\x32\x11.RecognizerAction\"\"\n\x10RecognizerResult\x12\x0e\n\x06result\x18\x01 \x01(\t*\'\n\x10RecognizerAction\x12\t\n\x05START\x10\x00\x12\x08\n\x04STOP\x10\x01\x32G\n\x11RecognizerService\x12\x32\n\tRecognize\x12\x12.RecognizerControl\x1a\x11.RecognizerResultb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'recognize_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _CONTROL._serialized_start=19
-  _CONTROL._serialized_end=57
-  _RESULT._serialized_start=59
-  _RESULT._serialized_end=83
-  _RECOGNIZERSERVICE._serialized_start=85
-  _RECOGNIZERSERVICE._serialized_end=136
+  _RECOGNIZERACTION._serialized_start=111
+  _RECOGNIZERACTION._serialized_end=150
+  _RECOGNIZERCONTROL._serialized_start=19
+  _RECOGNIZERCONTROL._serialized_end=73
+  _RECOGNIZERRESULT._serialized_start=75
+  _RECOGNIZERRESULT._serialized_end=109
+  _RECOGNIZERSERVICE._serialized_start=152
+  _RECOGNIZERSERVICE._serialized_end=223
 # @@protoc_insertion_point(module_scope)

--- a/python-server/recognize_pb2_grpc.py
+++ b/python-server/recognize_pb2_grpc.py
@@ -16,8 +16,8 @@ class RecognizerServiceStub(object):
         """
         self.Recognize = channel.unary_unary(
                 '/RecognizerService/Recognize',
-                request_serializer=recognize__pb2.Control.SerializeToString,
-                response_deserializer=recognize__pb2.Result.FromString,
+                request_serializer=recognize__pb2.RecognizerControl.SerializeToString,
+                response_deserializer=recognize__pb2.RecognizerResult.FromString,
                 )
 
 
@@ -35,8 +35,8 @@ def add_RecognizerServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
             'Recognize': grpc.unary_unary_rpc_method_handler(
                     servicer.Recognize,
-                    request_deserializer=recognize__pb2.Control.FromString,
-                    response_serializer=recognize__pb2.Result.SerializeToString,
+                    request_deserializer=recognize__pb2.RecognizerControl.FromString,
+                    response_serializer=recognize__pb2.RecognizerResult.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -60,7 +60,7 @@ class RecognizerService(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/RecognizerService/Recognize',
-            recognize__pb2.Control.SerializeToString,
-            recognize__pb2.Result.FromString,
+            recognize__pb2.RecognizerControl.SerializeToString,
+            recognize__pb2.RecognizerResult.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/python-server/record_client_grpc.py
+++ b/python-server/record_client_grpc.py
@@ -6,9 +6,9 @@ from time import sleep
 def run():
     with grpc.insecure_channel('0.0.0.0:50052') as channel:
         stub = recognize_pb2_grpc.RecognizerServiceStub(channel)
-        stub.Recognize(recognize_pb2.Control(start = 1, stop = 0))
+        result = stub.Recognize(recognize_pb2.RecognizerControl(action=recognize_pb2.START))
         sleep(10)
-        result = stub.Recognize(recognize_pb2.Control(start = 0, stop = 1))
+        result = stub.Recognize(recognize_pb2.RecognizerControl(action=recognize_pb2.STOP))
         print(result)
 
 if __name__ == '__main__':

--- a/python-server/record_server_grpc.py
+++ b/python-server/record_server_grpc.py
@@ -109,15 +109,16 @@ def voice_recognizer(filename):
 
 class RecognizerServiceServicer(recognize_pb2_grpc.RecognizerServiceServicer):
     def Recognize(self, request, context):
-        if request.start and not request.stop:
+
+        if request.action == recognize_pb2.RecognizerAction.START:
             record_from_microphone()
             result = "Recording..."
-        elif request.stop and not request.start:
+        elif request.action == recognize_pb2.RecognizerAction.STOP:
             stop_recording()
             result = voice_recognizer(url)
         else:
             result = "Some exception occured"
-        return recognize_pb2.Result(result = result)
+        return recognize_pb2.RecognizerResult(result = result)
 
 
 def main():


### PR DESCRIPTION
> Rename Control and Result Message by adding "Recognizer" subword before
> Change Control message use an enum of action types for the value in the Control message
> Regenerate protobuf specific files for python and dart
> Tested (working)